### PR TITLE
Bugfix for DSDPlus 1.074

### DIFF
--- a/dsdtune.c
+++ b/dsdtune.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[]) {
   char base_command[255];
   dsd_params params[] = {  { "dr",  1,   5, 0, 0, 0 }, 
                            { "dh",  1,   8, 0, 0, 0 },
-                           { "ds", 50,  80, 0, 0, 1 },
+                           { "ds", 55,  75, 0, 0, 1 }, /*DSDPlus 1.074 recognizes a range of 55-75*/
                            { "dd",  1, 100, 0, 0, 1 },
                            { "dv",  1,  30, 0, 0, 1 },
                            { "  ",  0,   0, 0, 0, 0 } }; /* GCC warns if this is 0 */


### PR DESCRIPTION
The latest version of DSDPlus no longer accepts the -ds switch with any value less than 55, and as a result, dsdtune will quit with a "Could not get decode string" error once it attempts to pass DSDPlus the -ds50 switch. All I've done is tweaked the start and end range for that specific test, and it fixed the issue.

DSDPlus v1.074's readme suggests the new lower and upper limits are 55 and 75 respectively, which is where I got the numbers for the tweak.

I've confirmed it's working as intended on my Windows 7 x64 box with DSDPlus 1.074. I compiled it under MinGW with GCC 4.8.1, zero issues.

The build command is pretty much identical to the one on your repo, I just called gcc directly instead of a cross compiler.
